### PR TITLE
Experiment with repeater (not for merging, just for demo)

### DIFF
--- a/src/states/detail.state.tsx
+++ b/src/states/detail.state.tsx
@@ -2,13 +2,14 @@ import createStateContext, {IAction} from './state';
 
 import dispatchIntercept from '../utils/dispatch-intercept';
 import {ITodo} from './todo.state';
+import repeater from '../utils/repeater';
 
 const initialState: IDetailState = null;
 const {
     useStateValue,
     StateProvider,
     StateContext
-} = createStateContext(detailReducer, initialState, dispatchIntercept);
+} = createStateContext(detailReducer, initialState, [dispatchIntercept, repeater('detail')]);
 
 // we do this only for DX
 const DISPLAY_NAME = 'DetailState';

--- a/src/states/state.tsx
+++ b/src/states/state.tsx
@@ -33,6 +33,7 @@ export type IStateProvider = FunctionComponent<PropsWithChildren<any>>
 export interface IAction {
     type: string;
     payload?: any;
+    __repeated?: boolean;
 }
 
 export type ContextState<T> = [T, Dispatch<IAction>];

--- a/src/states/time.state.tsx
+++ b/src/states/time.state.tsx
@@ -1,13 +1,14 @@
 import {useEffect} from 'react';
 
 import createStateContext, {IAction} from './state';
+import repeater from '../utils/repeater';
 
 const initialState: ITimeState = Date.now();
 const {
     useStateValue,
     StateProvider,
     StateContext
-} = createStateContext(timeReducer, initialState, useInterval);
+} = createStateContext(timeReducer, initialState, [useInterval, repeater('time')]);
 
 // we do this only for DX
 const DISPLAY_NAME = 'TimeState';

--- a/src/states/todo.state.tsx
+++ b/src/states/todo.state.tsx
@@ -6,6 +6,7 @@ import dispatchIntercept from '../utils/dispatch-intercept';
 import createStateContext, {IAction} from './state';
 
 import DUMMY_TODOS from '../data/dummy-todos'
+import repeater from '../utils/repeater';
 
 const STORAGE_KEY = 'foo-storage';
 const initialState: ITodoState = getInitialState();
@@ -13,7 +14,7 @@ const {
     useStateValue,
     StateProvider,
     StateContext
-} = createStateContext(todoReducer, initialState, [dispatchIntercept, useLocalStorage]);
+} = createStateContext(todoReducer, initialState, [dispatchIntercept, useLocalStorage, repeater('todo')]);
 
 // we do this only for DX
 const DISPLAY_NAME = 'TodoState';

--- a/src/utils/repeater.ts
+++ b/src/utils/repeater.ts
@@ -1,0 +1,39 @@
+// only dev
+import {Dispatch} from 'react';
+import {ContextState, IAction} from '../states/state';
+
+type DispatchObj = {
+  [str: string]:Dispatch<IAction>
+}
+
+const dispatches: DispatchObj = {}
+
+export default function repeater(name: string) {
+  console.log('loading repeater middleware: ', name);
+  
+  return function middleware<T>(_: T, dispatch: Dispatch<IAction>): ContextState<T>  {
+    const newDispatch: Dispatch<IAction> = (action, ...args) => {
+      console.log('dispatch in: ', name);
+      console.log('action: ', action);
+      
+      const newState = dispatch(action, ...args)
+      
+      // Bail if this isn't the original
+      if(action.__repeated) {
+        return newState
+      }
+
+      // Start repeating
+      Object.keys(dispatches).forEach(key => {
+        if(key === name) {
+          console.log('origin found, skipping', key);
+          return
+        }
+        console.log('repeating to', key);
+        dispatches[key]({...action, __repeated: true}, ...args)
+        })
+        return newState
+    };
+    dispatches[name] = newDispatch
+    return [_, newDispatch];
+}}


### PR DESCRIPTION
Yo!

Two things strike me as I play around with this.

1. In a smaller app it makes sense to have isolated action streams per state branch, but in a complex application the pattern of state branches listening and acting on other state branches action streams is very useful. Just hook into and listen for an action and do what you want to do.
Application init or clearing data actions are obvious examples but there are lots of them.
For this case I wanted to experiment to see if I could create a middleware that did this, and you can see the result in the changes of this PR.
I haven't experimented enough with this yet, I'm not sure if it re-renders even though no state update was made.

2. It would be pretty useful if the accepted middleware function signature / interface would match what Redux has. Because if that was case, there are many useful middlewares to choose from.
Maybe even Redux devtools would work (not sure if it's middleware or enhancer).

But this is a very cool thing that should be useful going forward.
I think we should continue to experiment with it a bit first, especially with the middlewares and what they're allowed to return and their signature.

Cheers 🥃 